### PR TITLE
Fix bug where pages deleted from trashcan was not properly deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add python 3.11 support (@marteinn)
 - Remove wagtailadmin.W003 warning in development (@marteinn)
 - Fix incorrect test alias in docker-entrypoint.sh (@marteinn)
+- Fix bug where pages deleted from trashcan was not properly deleted (@marteinn)
 
 ### Removed
 - Drop Wagtail 2.16 support

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -99,11 +99,14 @@ class TestAdmin(TestCase, WagtailTestUtils):
             self.client.post(delete_url)
             assert TrashCan.objects.count() == 1
 
-            delete_url = reverse("wagtailadmin_pages:delete", args=(new_page.id,))
+            trash_can_item = TrashCan.objects.first()
+            delete_url = trash_admin_url_helper.get_action_url(
+                "delete",
+                trash_can_item.id,
+            )
             self.client.post(delete_url)
-
-        assert not Page.objects.filter(title="delete page")
-        assert TrashCan.objects.count() == 0
+            assert not Page.objects.filter(title="delete page")
+            assert TrashCan.objects.count() == 0
 
     def test_removing_page_unpublishes_all_sub_pages(self):
         root_page = Page.objects.get(url_path="/")

--- a/wagtail_trash/wagtail_hooks.py
+++ b/wagtail_trash/wagtail_hooks.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.contrib.modeladmin.helpers import ButtonHelper, PermissionHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.contrib.modeladmin.views import IndexView
+from wagtail.contrib.modeladmin.views import DeleteView, IndexView
 
 if WAGTAIL_VERSION >= (3, 0):
     from wagtail import hooks
@@ -81,6 +81,21 @@ class TrashCanIndexView(IndexView):
         return _("Trash Can")
 
 
+class TrashCanDeleteView(DeleteView):
+    def confirmation_message(self):
+        return _(
+            "Are you sure you want to delete this %(object)s? If other things in your "
+            "site are related to it, they may also be affected."
+        ) % {"object": _("page")}
+
+    def delete_instance(self):
+        rb = self.instance
+        page = rb.page
+
+        page.delete(user=self.request.user)
+        rb.delete()
+
+
 class TrashCanModelAdmin(ModelAdmin):
     model = TrashCan
     menu_label = _("Trash Can")
@@ -95,6 +110,8 @@ class TrashCanModelAdmin(ModelAdmin):
 
     index_view_class = TrashCanIndexView
     index_template_name = "wagtail_trash/index.html"
+
+    delete_view_class = TrashCanDeleteView
 
     def page_tree(self, rb):
         descendants = rb.page.get_descendants(inclusive=True)


### PR DESCRIPTION
This PR fixes issue where deleted pages from trashcan was not properly deleted.

The reason for the pages was not being deleted is due to:
- Models in trashcan modeladmin are not pages but custom model `TrashCan`
- Since `TrashCan` is a custom model and not page, modeladmin does not use `wagtailadmin_pages:delete` when deleting pages but custom logic in its own DeleteView
- The custom delete logic deleted the `TrashCan` model, but not the associated `page`
- This results in the page not longer appearing in admin, but they still reside in the trashcan root page node
- Hence raising issues when another page with the same slug being added to the same node

This PR:
- Adds a custom model view that deletes both the TrashCan model instance and the associated page
- Adds a test against the model view

This solves https://github.com/Frojd/wagtail-trash/issues/15 and also by accident solves https://github.com/Frojd/wagtail-trash/issues/2